### PR TITLE
FLINK-38035: Redact sensitive env vars in PythonEnvUtils logging

### DIFF
--- a/flink-python/src/main/java/org/apache/flink/client/python/PythonEnvUtils.java
+++ b/flink-python/src/main/java/org/apache/flink/client/python/PythonEnvUtils.java
@@ -370,15 +370,7 @@ final class PythonEnvUtils {
         }
         LOG.info(
             "Starting Python process with environment variables: {}, command: {}",
-            env.entrySet().stream()
-                .map(e -> {
-                    String key = e.getKey();
-                    String value = key.toUpperCase().matches(".*(SECRET|TOKEN|PASSWORD|KEY).*")
-                        ? "***REDACTED***"
-                        : e.getValue();
-                    return key + "=" + value;
-                    })
-                .collect(Collectors.joining(", ")),
+            redactEnv(env),
             String.join(" ", commands));
         Process process = pythonProcessBuilder.start();
         if (!process.isAlive()) {
@@ -548,5 +540,25 @@ final class PythonEnvUtils {
                 gatewayServer.shutdown();
             }
         }
+    }
+
+    /**
+     * Redacts values of sensitive environment variables before logging.
+     * Keys containing patterns such as SECRET, TOKEN, PASSWORD, or KEY (case-insensitive)
+     * will have their values replaced with "***REDACTED***".
+     *
+     * @param environment a map of environment variables
+     * @return a string of key=value pairs with sensitive values redacted
+     */
+    public static String redactEnv(Map<String, String> environment) {
+    return environment.entrySet().stream()
+        .map(e -> {
+            String key = e.getKey();
+            String value = key.toUpperCase().matches(".*(SECRET|TOKEN|PASSWORD|KEY).*")
+                ? "***REDACTED***"
+                : e.getValue();
+            return key + "=" + value;
+        })
+        .collect(Collectors.joining(", "));
     }
 }

--- a/flink-python/src/main/java/org/apache/flink/client/python/PythonEnvUtils.java
+++ b/flink-python/src/main/java/org/apache/flink/client/python/PythonEnvUtils.java
@@ -368,13 +368,18 @@ final class PythonEnvUtils {
             // set the child process the output same as the parent process.
             pythonProcessBuilder.redirectOutput(ProcessBuilder.Redirect.INHERIT);
         }
-
         LOG.info(
-                "Starting Python process with environment variables: {{}}, command: {}",
-                env.entrySet().stream()
-                        .map(e -> e.getKey() + "=" + e.getValue())
-                        .collect(Collectors.joining(", ")),
-                String.join(" ", commands));
+            "Starting Python process with environment variables: {}, command: {}",
+            env.entrySet().stream()
+                .map(e -> {
+                    String key = e.getKey();
+                    String value = key.toUpperCase().matches(".*(SECRET|TOKEN|PASSWORD|KEY).*")
+                        ? "***REDACTED***"
+                        : e.getValue();
+                    return key + "=" + value;
+                    })
+                .collect(Collectors.joining(", ")),
+            String.join(" ", commands));
         Process process = pythonProcessBuilder.start();
         if (!process.isAlive()) {
             throw new RuntimeException("Failed to start Python process. ");

--- a/flink-python/src/test/java/org/apache/flink/client/python/PythonEnvUtilsTest.java
+++ b/flink-python/src/test/java/org/apache/flink/client/python/PythonEnvUtilsTest.java
@@ -252,6 +252,33 @@ class PythonEnvUtilsTest {
         assertThat(actualPaths).isEqualTo(expectedPythonPaths);
     }
 
+    @Test
+    public void testRedactEnv() {
+        Map<String, String> env = new HashMap<>();
+        env.put("AWS_SECRET_ACCESS_KEY", "secret123");
+        env.put("MY_TOKEN", "token456");
+        env.put("DATABASE_PASSWORD", "pass789");
+        env.put("ACCESS_KEY", "keyABC");
+        env.put("NORMAL_VAR", "safe-value");
+
+        String result = PythonEnvUtils.redactEnv(env);
+
+        // Assert sensitive values are redacted
+        assertTrue(result.contains("AWS_SECRET_ACCESS_KEY=***REDACTED***"));
+        assertTrue(result.contains("MY_TOKEN=***REDACTED***"));
+        assertTrue(result.contains("DATABASE_PASSWORD=***REDACTED***"));
+        assertTrue(result.contains("ACCESS_KEY=***REDACTED***"));
+
+        // Assert normal values are intact
+        assertTrue(result.contains("NORMAL_VAR=safe-value"));
+
+        // Ensure no sensitive values are leaked
+        assertFalse(result.contains("secret123"));
+        assertFalse(result.contains("token456"));
+        assertFalse(result.contains("pass789"));
+        assertFalse(result.contains("keyABC"));
+    }
+
     @AfterEach
     void cleanEnvironment() {
         FileUtils.deleteDirectoryQuietly(new File(tmpDirPath));


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

This pull request addresses a security concern in PyFlink’s environment logging. Previously, all environment variables were logged in plaintext when launching a Python process, which could unintentionally expose sensitive credentials (such as AWS_SECRET_ACCESS_KEY, TOKEN, PASSWORD, etc.) in log files. This change introduces logic to detect and redact sensitive environment variable values, replacing them with `***REDACTED***` before they are written to logs. This helps align PyFlink behavior with best practices for security and production environments, particularly in cloud and containerized setups.


## Brief change log

- Introduced a filter in PythonEnvUtils to scan environment variable keys for sensitive terms (SECRET, TOKEN, PASSWORD, KEY, etc.).
- Modified the environment logging logic to redact sensitive values inline before outputting them to logs.
- Ensured the logging format remains unchanged to preserve log structure and readability.


## Verifying this change

* This change is already covered by existing functional test cases that verify PyFlink process initialization. The change only affects log output formatting and does not alter core logic or behavior.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
